### PR TITLE
Fix issue where scrolling gets stuck on second to last row/column

### DIFF
--- a/ChipsLayoutManager/src/main/java/com/beloo/widget/chipslayoutmanager/ScrollingController.java
+++ b/ChipsLayoutManager/src/main/java/com/beloo/widget/chipslayoutmanager/ScrollingController.java
@@ -132,7 +132,7 @@ abstract class ScrollingController implements IScrollingController {
         if (lastViewAdapterPos < itemCount - 1) { //in case lower view isn't the last view in adapter
             delta = d;
         } else { //in case lower view is the last view in adapter and wouldn't be any other view below
-            int viewEnd = stateFactory.getEndViewBound();
+            int viewEnd = canvas.isInside(lastView) ? stateFactory.getEndViewBound() : stateFactory.getEnd(lastView);
             int parentEnd = stateFactory.getEndAfterPadding();
             delta = Math.min(viewEnd - parentEnd, d);
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 23 11:38:19 EET 2016
+#Fri May 26 11:40:38 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Fixes #40 
Views are added to the layout manager before they are inside the canvas, which would cause the last child views in the layout manager to be ignored in the canvas `findBorderViews()` method.  This caused a case where `stateFactory.getEndViewBound()` was returning the end position of the previous row/column instead of the end of the row/column containing the last child.  This was preventing scrolling past the second to last row because the scrolling controller thought the last view's end had reached the parent end.