### PR TITLE
fix ScrollingController computeScroll bug

### DIFF
--- a/ChipsLayoutManager/src/main/java/com/beloo/widget/chipslayoutmanager/ScrollingController.java
+++ b/ChipsLayoutManager/src/main/java/com/beloo/widget/chipslayoutmanager/ScrollingController.java
@@ -173,8 +173,8 @@ abstract class ScrollingController implements IScrollingController {
             return 0;
         }
 
-        int firstVisiblePos = lm.findFirstVisibleItemPosition();
-        int lastVisiblePos = lm.findLastVisibleItemPosition();
+        int firstVisiblePos = lm.findFirstCompletelyVisibleItemPosition();
+        int lastVisiblePos = lm.findLastCompletelyVisibleItemPosition();
         final int itemsBefore = Math.max(0, firstVisiblePos);
 
         if (!lm.isSmoothScrollbarEnabled()) {
@@ -196,8 +196,8 @@ abstract class ScrollingController implements IScrollingController {
             return 0;
         }
 
-        int firstVisiblePos = lm.findFirstVisibleItemPosition();
-        int lastVisiblePos = lm.findLastVisibleItemPosition();
+        int firstVisiblePos = lm.findFirstCompletelyVisibleItemPosition();
+        int lastVisiblePos = lm.findLastCompletelyVisibleItemPosition();
 
         if (!lm.isSmoothScrollbarEnabled()) {
             return Math.abs(lastVisiblePos - firstVisiblePos) + 1;
@@ -215,8 +215,8 @@ abstract class ScrollingController implements IScrollingController {
             return state.getItemCount();
         }
 
-        int firstVisiblePos = lm.findFirstVisibleItemPosition();
-        int lastVisiblePos = lm.findLastVisibleItemPosition();
+        int firstVisiblePos = lm.findFirstCompletelyVisibleItemPosition();
+        int lastVisiblePos = lm.findLastCompletelyVisibleItemPosition();
 
         // smooth scrollbar enabled. try to estimate better.
         final int laidOutRange = Math.abs(firstVisiblePos - lastVisiblePos) + 1;


### PR DESCRIPTION
 When using `RecyclerView.canScrollVertically()` , the first item is not completely visible but it still return false. Refer to the code from `LinearLayoutManager` ，use `findFirstCompletelyVisibleItemPosition` and `findLastCompletelyVisibleItemPosition` is the effective way to compute scroll offset.